### PR TITLE
Add solution for lesson 1

### DIFF
--- a/lesson-1/binary-gap/Rakefile
+++ b/lesson-1/binary-gap/Rakefile
@@ -1,0 +1,3 @@
+task :test do
+  ruby 'test.rb'
+end

--- a/lesson-1/binary-gap/binary_gap.rb
+++ b/lesson-1/binary-gap/binary_gap.rb
@@ -1,0 +1,10 @@
+# https://codility.com/programmers/lessons/1-iterations/binary_gap/
+module BinaryGap
+  def solution(n)
+    binary = n.to_s(2)
+    gaps = binary.split('1')
+    gaps.pop if n.even?
+    return 0 if gaps.empty?
+    gaps.map(&:length).max
+  end
+end

--- a/lesson-1/binary-gap/test.rb
+++ b/lesson-1/binary-gap/test.rb
@@ -1,0 +1,30 @@
+require './binary_gap.rb'
+require 'minitest/autorun'
+include BinaryGap
+
+describe BinaryGap do
+  it 'correctly returns non-zero value for valid data' do
+    n = 17
+    expected_longest_gap_value = 3
+    assert_equal(expected_longest_gap_value, solution(n))
+  end
+
+  it 'correctly returns zero value for valid data' do
+    n = 15
+    expected_longest_gap_value = 0
+    assert_equal(expected_longest_gap_value, solution(n))
+  end
+
+  it 'returns correct value for trailing zeros' do
+    n = 6
+    expected_longest_gap_value = 0
+    assert_equal(expected_longest_gap_value, solution(n))
+  end
+
+  it 'returns correct value when \
+      the last gap in the string was not the longest one' do
+    n = 1041
+    expected_longest_gap_value = 5
+    assert_equal(expected_longest_gap_value, solution(n))
+  end
+end

--- a/lesson-1/binary-gap/test.rb
+++ b/lesson-1/binary-gap/test.rb
@@ -6,25 +6,25 @@ describe BinaryGap do
   it 'correctly returns non-zero value for valid data' do
     n = 17
     expected_longest_gap_value = 3
-    assert_equal(expected_longest_gap_value, solution(n))
+    expect(solution(n)).must_equal expected_longest_gap_value
   end
 
   it 'correctly returns zero value for valid data' do
     n = 15
     expected_longest_gap_value = 0
-    assert_equal(expected_longest_gap_value, solution(n))
+    expect(solution(n)).must_equal expected_longest_gap_value
   end
 
   it 'returns correct value for trailing zeros' do
     n = 6
     expected_longest_gap_value = 0
-    assert_equal(expected_longest_gap_value, solution(n))
+    expect(solution(n)).must_equal expected_longest_gap_value
   end
 
   it 'returns correct value when \
       the last gap in the string was not the longest one' do
     n = 1041
     expected_longest_gap_value = 5
-    assert_equal(expected_longest_gap_value, solution(n))
+    expect(solution(n)).must_equal expected_longest_gap_value
   end
 end


### PR DESCRIPTION
Find the consecutive 0s by splitting the binary representation of passed value on 1s. If passed argument is even, then we have to remove the last string of 0s, as that string is not closed by "1" (and therefore does not match the definition of a binary gap). Return the length of a longest string as a result.